### PR TITLE
Faster q3_0 implementation, using two planes

### DIFF
--- a/ggml.c
+++ b/ggml.c
@@ -608,8 +608,10 @@ static_assert(sizeof(block_q2_0) == sizeof(ggml_fp16_t) + QK2_0 / 4, "wrong q2_0
 #define QK3_0 16
 typedef struct {
     ggml_fp16_t d;
-    uint16_t qhi;
-    uint32_t qlo;
+    // Instead of representing q3_0 as a packed format "...210210210210",
+    // represent it as two planes: "...10101010" and "...2222"
+    uint16_t qhi; // The highest bit of each 3-bit number, packed together
+    uint32_t qlo; // The low 2-bits of each 3-bit number, packed together
 } block_q3_0;
 static_assert(sizeof(block_q3_0) == sizeof(ggml_fp16_t) + QK3_0 * 3 / 8, "wrong q3_0 size/padding");
 


### PR DESCRIPTION
This reimplements block_q3_0 as: 
```
typedef struct {
    ggml_fp16_t d;
    uint16_t qhi;
    uint32_t qlo;
} block_q3_0;
```
For each 3-bit number, the lowest 2 bits are packed into `qlo`, while the highest bit is packed into `qhi`. 

To convert this representation to SIMD vectors, `qlo` is unpacked exactly like q2_0, while `qhi` is converted to a lookup table whose results are then OR'd.

This representation is both faster, and simpler regarding SIMD as it's implementation shares most code with q2_0. I'm seeing an improvement from 66.07 seconds per pass to 42.12 seconds per pass on AVX2.

Pros:
- Simpler SIMD implementation
- Faster
- Shares code with q2_0

Cons:
- The data representation is unusual
- Requires a lookup table